### PR TITLE
add Haskell bindings

### DIFF
--- a/src/epitech/std_comment.el
+++ b/src/epitech/std_comment.el
@@ -1,6 +1,6 @@
 ;;
 ;; EPITECH PROJECT, 2018
-;; emacs configuration
+;; epitech-emacs
 ;; File description:
 ;; standard epitech header configuration
 ;;
@@ -31,6 +31,7 @@
       std-python-alist          '( (cs . "#!/usr/bin/env python3\n##") (cc . "## ") (ce . "##") )
       std-ruby-alist            '( (cs . "#!/usr/bin/env ruby\n##") (cc . "## ") (ce . "##") )
       std-node-alist            '( (cs . "#!/usr/bin/env node\n/*") (cc . "** ") (ce . "*/") )
+      std-haskell-alist         '( (cs . "{-") (cc . "-- ") (ce . "-}") )
       )
 
 
@@ -64,7 +65,8 @@
                         ("LaTeX"                . std-latex-alist)
                         ("Python"               . std-python-alist)
                         ("Ruby"                 . std-ruby-alist)
-                        ("JavaScript"           . std-node-alist))
+                        ("JavaScript"           . std-node-alist)
+                        ("Haskell"              . std-haskell-alist))
       )
 
 (defun std-get (a)


### PR DESCRIPTION
Allows to use ^C^H with Haskell source files to add an Epitech header